### PR TITLE
Build against stt

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,6 +2,6 @@ plugin_LTLIBRARIES = libgstdeepspeech.la
 libgstdeepspeech_la_SOURCES = gstdeepspeech.cc gstdeepspeech.h
 libgstdeepspeech_la_CXXFLAGS = $(GST_CFLAGS)
 libgstdeepspeech_la_LIBADD = $(GST_LIBS)
-libgstdeepspeech_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS) -ldeepspeech
+libgstdeepspeech_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS) -lstt
 libgstdeepspeech_la_LIBTOOLFLAGS = --tag=disable-static
 noinst_HEADERS = gstdeepspeech.h

--- a/src/gstdeepspeech.cc
+++ b/src/gstdeepspeech.cc
@@ -60,7 +60,6 @@
 #endif
 
 #include <gst/gst.h>
-#include <deepspeech.h>
 #include <string.h>
 #include <sstream>
 
@@ -132,8 +131,8 @@ gpointer run_model_async(void * instance_data, void * pool_data)
   g_mutex_lock(&mutex);
   void *data = malloc(sizeof(short) * info.size);
   memcpy(data, info.data, info.size);
-  DS_FeedAudioContent(deepspeech->streaming_state, (const short *) data, (unsigned int) info.size);
-  result = DS_IntermediateDecode(deepspeech->streaming_state);
+  STT_FeedAudioContent(deepspeech->streaming_state, (const short *) data, (unsigned int) info.size);
+  result = STT_IntermediateDecode(deepspeech->streaming_state);
   g_mutex_unlock(&mutex);
 
   if (strlen(result) > 0) {
@@ -154,8 +153,8 @@ void process_final_text(GstDeepSpeech * deepspeech, GstBuffer *buf) {
   gst_buffer_map(buf, &info, GST_MAP_READ);
   void *data = malloc(sizeof(short) * info.size);
   memcpy(data, info.data, info.size);
-  DS_FeedAudioContent(deepspeech->streaming_state, (const short *) data, (unsigned int) info.size);
-  result = DS_FinishStream(deepspeech->streaming_state);
+  STT_FeedAudioContent(deepspeech->streaming_state, (const short *) data, (unsigned int) info.size);
+  result = STT_FinishStream(deepspeech->streaming_state);
 
   if (strlen(result) > 0) {
     GstMessage *msg = gst_deepspeech_message_new (deepspeech, buf, result, false);
@@ -249,21 +248,21 @@ gst_deepspeech_init (GstDeepSpeech * deepspeech)
 static void
 gst_deepspeech_load_model (GstDeepSpeech * deepspeech)
 {
-  int status = DS_CreateModel(deepspeech->speech_model_path, &deepspeech->model_state);
+  int status = STT_CreateModel(deepspeech->speech_model_path, &deepspeech->model_state);
   if (status != 0) {
     fprintf(stderr, "Could not create model.\n");
     return;
   }
 
-  DS_SetModelBeamWidth(deepspeech->model_state, DEFAULT_BEAM_WIDTH);
+  STT_SetModelBeamWidth(deepspeech->model_state, DEFAULT_BEAM_WIDTH);
 
-  status = DS_EnableExternalScorer(deepspeech->model_state, deepspeech->scorer_path); 
+  status = STT_EnableExternalScorer(deepspeech->model_state, deepspeech->scorer_path); 
   if (status != 0) {
     fprintf(stderr, "Could not enable scorer.\n");
     return;
   }
 
-  status = DS_CreateStream(deepspeech->model_state, &deepspeech->streaming_state);
+  status = STT_CreateStream(deepspeech->model_state, &deepspeech->streaming_state);
   if (status != 0) {
     fprintf(stderr, "Could not create stream.\n");
     return;

--- a/src/gstdeepspeech.h
+++ b/src/gstdeepspeech.h
@@ -46,7 +46,7 @@
 
 #include <gst/gst.h>
 #include <gst/base/gstbasetransform.h>
-#include "deepspeech.h"
+#include <coqui-stt.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
It was dropped by Mozilla so some of the responsible employees launched a startup.
Currently targeting 0.9.3, which is API compatible with the original Deepspeech.
